### PR TITLE
Invert go version test for ldflags

### DIFF
--- a/build.go
+++ b/build.go
@@ -269,14 +269,13 @@ type Constants map[string]string
 func (cs Constants) LDFlags() string {
 	l := make([]string, 0, len(cs))
 
-	v := runtime.Version()
-	if strings.HasPrefix(v, "go1.5") || strings.HasPrefix(v, "go1.6") {
+	if runtime.Version() < "go1.5" {
 		for k, v := range cs {
-			l = append(l, fmt.Sprintf(`-X "%s=%s"`, k, v))
+			l = append(l, fmt.Sprintf(`-X %q %q`, k, v))
 		}
 	} else {
 		for k, v := range cs {
-			l = append(l, fmt.Sprintf(`-X %q %q`, k, v))
+			l = append(l, fmt.Sprintf(`-X "%s=%s"`, k, v))
 		}
 	}
 


### PR DESCRIPTION
Allow compilation with go1.7.1.