### PR TITLE
Add monitor ID (derived from EDID)

### DIFF
--- a/cmd_show.go
+++ b/cmd_show.go
@@ -1,0 +1,32 @@
+package main
+
+import "fmt"
+
+type CmdShow struct{}
+
+func init() {
+	_, err := parser.AddCommand("show",
+		"show monitors and IDs",
+		"The show command lists all connected monitors with their IDs",
+		&CmdShow{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ListOutput(output Output) {
+	fmt.Printf("%- 10s %s\n", output.Name, output.MonitorId)
+}
+
+func (cmd CmdShow) Execute(args []string) error {
+	outputs, err := DetectOutputs()
+	if err != nil {
+		return err
+	}
+	for _, output := range outputs {
+		if output.Connected {
+			ListOutput(output)
+		}
+	}
+	return nil
+}

--- a/doc/grobi.conf
+++ b/doc/grobi.conf
@@ -44,6 +44,22 @@ rules:
     execute_after:
       - xautolock -enable
 
+  # This is a rule for connecting the TV in the living room
+  - name: TV
+
+    # We only want to match the TV, so we identify it with its monitor ID. In order to get the
+    # monitor ID, we connect the TV and run `grobi show`, which lists all connected monitors
+    # with their monitor ID (which consists of a three letter manufacturer code, a product and
+    # a serial number). We can now match the connected outputs with this monitor ID.
+    # We specify the monitor ID after the port with a dash in between those two values.
+    outputs_connected: 
+      - HDMI1-SAM-2618-808661557
+
+    configure_single: HDMI1
+
+    execute_after:
+      - xautolock -disable
+
 
   # This is a rule for mobile computing, i.e. outside of the docking station defined above.
   - name: Mobile

--- a/randr.go
+++ b/randr.go
@@ -75,11 +75,20 @@ type Outputs []Output
 // Present returns true iff the list of outputs contains the named output.
 func (os Outputs) Present(name string) bool {
 	for _, o := range os {
+		// Check legacy name
 		m, err := path.Match(name, o.Name)
 		if err != nil {
 			return false
 		}
+		if m {
+			return true
+		}
 
+		// Check extended name
+		m, err = path.Match(name, o.Name+"-"+o.MonitorId)
+		if err != nil {
+			return false
+		}
 		if m {
 			return true
 		}
@@ -91,12 +100,25 @@ func (os Outputs) Present(name string) bool {
 // it is connected.
 func (os Outputs) Connected(name string) bool {
 	for _, o := range os {
+		if !o.Connected {
+			continue
+		}
+
+		// Check legacy name
 		m, err := path.Match(name, o.Name)
 		if err != nil {
 			return false
 		}
+		if m {
+			return true
+		}
 
-		if m && o.Connected {
+		// Check extended name
+		m, err = path.Match(name, o.Name+"-"+o.MonitorId)
+		if err != nil {
+			return false
+		}
+		if m {
 			return true
 		}
 	}

--- a/randr_test.go
+++ b/randr_test.go
@@ -409,7 +409,7 @@ VIRTUAL1 disconnected (normal left inverted right x axis y axis)`,
 				},
 				Connected: true,
 				Primary:   true,
-				Edid: "00ffffffffffff000daeb114000000000c190104951f117802ff35925552952925505400000001010101010101010101010101010101b43b804a71383440503c680034ad10000018000000fe004e3134304843452d4541410a20000000fe00434d4e0a202020202020202020000000fe004e3134304843452d4541410a2000a2",
+				MonitorId: "CMN-5297-0",
 			},
 			Output{Name: "DP1"},
 			Output{Name: "DP2"},
@@ -433,7 +433,7 @@ VIRTUAL1 disconnected (normal left inverted right x axis y axis)`,
 					{Name: "720x400"},
 				},
 				Connected: true,
-				Edid: "00ffffffffffff004c2d3a0a353233302417010380351e782af711a3564f9e280f5054bfef80714f81c0810081809500a9c0b3000101023a801871382d40582c4500132b2100001e011d007251d01e206e285500132b2100001e000000fd00324b1e5111000a202020202020000000fc00533234433335300a2020202020011802031af14690041f130312230907078301000066030c00100080011d00bc52d01e20b8285540132b2100001e8c0ad090204031200c405500132b210000188c0ad08a20e02d10103e9600132b21000018000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000099",
+				MonitorId: "SAM-2618-808661557",
 			},
 			Output{Name: "VIRTUAL1"},
 		},
@@ -481,10 +481,10 @@ func TestRandrParse(t *testing.T) {
 					out1.Modes, out2.Modes)
 			}
 
-			if out1.Edid != out2.Edid {
-				t.Errorf("test %d, output %d: Edids not equal:\n  want %v\n  got  %v",
+			if out1.MonitorId != out2.MonitorId {
+				t.Errorf("test %d, output %d: Monitor IDs not equal:\n  want %v\n  got  %v",
 					ti, i,
-					out1.Edid, out2.Edid)
+					out1.MonitorId, out2.MonitorId)
 			}
 		}
 	}
@@ -591,6 +591,63 @@ func TestParseModeLine(t *testing.T) {
 		if !reflect.DeepEqual(mode, test.mode) {
 			t.Errorf("test %d failed: expected Mode not found", i)
 			continue
+		}
+	}
+}
+
+var TestEdids = []struct {
+	edid      string
+	failure   bool
+	monitorId string
+}{
+	{
+		"00ffffffffffff004c2d3a0a353233302417010380351e782af711a3564f9e280f5054bfef80714f81c0810081809500a9c0b3000101023a801871382d40582c4500132b2100001e011d007251d01e206e285500132b2100001e000000fd00324b1e5111000a202020202020000000fc00533234433335300a2020202020011802031af14690041f130312230907078301000066030c00100080011d00bc52d01e20b8285540132b2100001e8c0ad090204031200c405500132b210000188c0ad08a20e02d10103e9600132b21000018000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000099",
+		false,
+		"SAM-2618-808661557",
+	},
+	{
+		"00ffffffffffff000daeb114000000000c190104951f117802ff35925552952925505400000001010101010101010101010101010101b43b804a71383440503c680034ad10000018000000fe004e3134304843452d4541410a20000000fe00434d4e0a202020202020202020000000fe004e3134304843452d4541410a2000a2",
+		false,
+		"CMN-5297-0",
+	},
+	{
+		"",
+		true,
+		"",
+	},
+	{
+		"00ffffffffffff004c2d3a0a3532333",
+		true,
+		"",
+	},
+	{
+		"00ffffffffffff004c2d3a0a35323330",
+		false,
+		"SAM-2618-808661557",
+	},
+	{
+		"00ffffeeffffff000daeb114000000000c190104951f117802ff35925552952925505400000001010101010101010101010101010101b43b804a71383440503c680034ad10000018000000fe004e3134304843452d4541410a20000000fe00434d4e0a202020202020202020000000fe004e3134304843452d4541410a2000a2",
+		true,
+		"",
+	},
+}
+
+func TestGenerateMonitorId(t *testing.T) {
+	for i, test := range TestEdids {
+		monitorId, err := GenerateMonitorId(test.edid)
+		if test.failure {
+			if err == nil {
+				t.Errorf("test %d did not return the expected error, but result: %v", i, monitorId)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("test %d failed: produced unexpected error: %v", i, err)
+			continue
+		}
+
+		if monitorId != test.monitorId {
+			t.Errorf("test %d failed: expected monitor ID: '%s', got monitor ID: '%s'", i, test.monitorId, monitorId)
 		}
 	}
 }

--- a/randr_test.go
+++ b/randr_test.go
@@ -293,6 +293,151 @@ VIRTUAL1 disconnected (normal left inverted right x axis y axis)`,
 			},
 		},
 	},
+	{
+		`Screen 0: minimum 8 x 8, current 3840 x 1080, maximum 32767 x 32767
+eDP1 connected primary 1920x1080+1920+0 (normal left inverted right x axis y axis) 310mm x 170mm
+	EDID: 
+		00ffffffffffff000daeb11400000000
+		0c190104951f117802ff359255529529
+		25505400000001010101010101010101
+		010101010101b43b804a71383440503c
+		680034ad10000018000000fe004e3134
+		304843452d4541410a20000000fe0043
+		4d4e0a202020202020202020000000fe
+		004e3134304843452d4541410a2000a2
+	BACKLIGHT: 332 
+		range: (0, 852)
+	Backlight: 332 
+		range: (0, 852)
+	scaling mode: Full aspect 
+		supported: None, Full, Center, Full aspect
+	Broadcast RGB: Automatic 
+		supported: Automatic, Full, Limited 16:235
+	audio: auto 
+		supported: force-dvi, off, auto, on
+   1920x1080     60.01*+
+   1400x1050     59.98  
+   1600x900      60.00  
+   1280x1024     60.02  
+   1280x960      60.00  
+   1368x768      60.00  
+   1280x720      60.00  
+   1024x768      60.00  
+   1024x576      60.00  
+   960x540       60.00  
+   800x600       60.32    56.25  
+   864x486       60.00  
+   640x480       59.94  
+   720x405       60.00  
+   640x360       60.00  
+DP1 disconnected (normal left inverted right x axis y axis)
+	Broadcast RGB: Automatic 
+		supported: Automatic, Full, Limited 16:235
+	audio: auto 
+		supported: force-dvi, off, auto, on
+DP2 disconnected (normal left inverted right x axis y axis)
+	Broadcast RGB: Automatic 
+		supported: Automatic, Full, Limited 16:235
+	audio: auto 
+		supported: force-dvi, off, auto, on
+HDMI1 disconnected (normal left inverted right x axis y axis)
+	aspect ratio: Automatic 
+		supported: Automatic, 4:3, 16:9
+	Broadcast RGB: Automatic 
+		supported: Automatic, Full, Limited 16:235
+	audio: auto 
+		supported: force-dvi, off, auto, on
+HDMI2 connected 1920x1080+0+0 (normal left inverted right x axis y axis) 530mm x 300mm
+	EDID: 
+		00ffffffffffff004c2d3a0a35323330
+		2417010380351e782af711a3564f9e28
+		0f5054bfef80714f81c0810081809500
+		a9c0b3000101023a801871382d40582c
+		4500132b2100001e011d007251d01e20
+		6e285500132b2100001e000000fd0032
+		4b1e5111000a202020202020000000fc
+		00533234433335300a20202020200118
+		02031af14690041f1303122309070783
+		01000066030c00100080011d00bc52d0
+		1e20b8285540132b2100001e8c0ad090
+		204031200c405500132b210000188c0a
+		d08a20e02d10103e9600132b21000018
+		00000000000000000000000000000000
+		00000000000000000000000000000000
+		00000000000000000000000000000099
+	aspect ratio: Automatic 
+		supported: Automatic, 4:3, 16:9
+	Broadcast RGB: Automatic 
+		supported: Automatic, Full, Limited 16:235
+	audio: auto 
+		supported: force-dvi, off, auto, on
+   1920x1080     60.00*+  50.00    59.94  
+   1680x1050     59.88  
+   1600x900      60.00  
+   1280x1024     75.02    60.02  
+   1440x900      59.90  
+   1280x800      59.91  
+   1152x864      75.00  
+   1280x720      60.00    50.00    59.94  
+   1024x768      75.03    70.07    60.00  
+   832x624       74.55  
+   800x600       72.19    75.00    60.32    56.25  
+   720x576       50.00  
+   720x480       60.00    59.94  
+   640x480       75.00    72.81    66.67    60.00    59.94  
+   720x400       70.08  
+VIRTUAL1 disconnected (normal left inverted right x axis y axis)`,
+		[]Output{
+			Output{
+				Name: "eDP1",
+				Modes: []Mode{
+					{Name: "1920x1080", Default: true, Active: true},
+					{Name: "1400x1050"},
+					{Name: "1600x900"},
+					{Name: "1280x1024"},
+					{Name: "1280x960"},
+					{Name: "1368x768"},
+					{Name: "1280x720"},
+					{Name: "1024x768"},
+					{Name: "1024x576"},
+					{Name: "960x540"},
+					{Name: "800x600"},
+					{Name: "864x486"},
+					{Name: "640x480"},
+					{Name: "720x405"},
+					{Name: "640x360"},
+				},
+				Connected: true,
+				Primary:   true,
+				Edid: "00ffffffffffff000daeb114000000000c190104951f117802ff35925552952925505400000001010101010101010101010101010101b43b804a71383440503c680034ad10000018000000fe004e3134304843452d4541410a20000000fe00434d4e0a202020202020202020000000fe004e3134304843452d4541410a2000a2",
+			},
+			Output{Name: "DP1"},
+			Output{Name: "DP2"},
+			Output{Name: "HDMI1"},
+			Output{Name: "HDMI2",
+				Modes: []Mode{
+					{Name: "1920x1080", Default: true, Active: true},
+					{Name: "1680x1050"},
+					{Name: "1600x900"},
+					{Name: "1280x1024"},
+					{Name: "1440x900"},
+					{Name: "1280x800"},
+					{Name: "1152x864"},
+					{Name: "1280x720"},
+					{Name: "1024x768"},
+					{Name: "832x624"},
+					{Name: "800x600"},
+					{Name: "720x576"},
+					{Name: "720x480"},
+					{Name: "640x480"},
+					{Name: "720x400"},
+				},
+				Connected: true,
+				Edid: "00ffffffffffff004c2d3a0a353233302417010380351e782af711a3564f9e280f5054bfef80714f81c0810081809500a9c0b3000101023a801871382d40582c4500132b2100001e011d007251d01e206e285500132b2100001e000000fd00324b1e5111000a202020202020000000fc00533234433335300a2020202020011802031af14690041f130312230907078301000066030c00100080011d00bc52d01e20b8285540132b2100001e8c0ad090204031200c405500132b210000188c0ad08a20e02d10103e9600132b21000018000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000099",
+			},
+			Output{Name: "VIRTUAL1"},
+		},
+	},
 }
 
 func TestRandrParse(t *testing.T) {
@@ -334,6 +479,12 @@ func TestRandrParse(t *testing.T) {
 				t.Errorf("test %d, output %d: list of modes not equal:\n  want %v\n  got  %v",
 					ti, i,
 					out1.Modes, out2.Modes)
+			}
+
+			if out1.Edid != out2.Edid {
+				t.Errorf("test %d, output %d: Edids not equal:\n  want %v\n  got  %v",
+					ti, i,
+					out1.Edid, out2.Edid)
 			}
 		}
 	}

--- a/rule_test.go
+++ b/rule_test.go
@@ -53,6 +53,24 @@ var testRules = []struct {
 		},
 		false,
 	},
+	{
+		Rule{
+			OutputsPresent: []string{"HDMI-SAM-2618-808661557"},
+		},
+		true,
+	},
+	{
+		Rule{
+			OutputsPresent: []string{"*-UNK-123-456"},
+		},
+		false,
+	},
+	{
+		Rule{
+			OutputsDisconnected: []string{"HDMI-UNK-123-456"},
+		},
+		true,
+	},
 }
 
 var testOutputs = []Output{
@@ -63,6 +81,7 @@ var testOutputs = []Output{
 			{"1377x768", true, true},
 			{"1024x768", false, false},
 		},
+		MonitorId: "CMN-5297-0",
 	},
 	{
 		Name:      "VGA",
@@ -79,6 +98,7 @@ var testOutputs = []Output{
 			{"1920x1080", true, true},
 			{"1024x768", false, false},
 		},
+		MonitorId: "SAM-2618-808661557",
 	},
 	{
 		Name: "DP2-1",


### PR DESCRIPTION
I added the monitor ID for my own use case. I also played around with changing the configuration language to HCL, but could not figure out a nice way. So I just changed the current YAML format, which can be seen in the diff for `doc/grobi.conf`.

You might not want to merge this as is, because it is a breaking config change. It might be best, if you switch the configuration language yourself.

I am currently running this version of grobi and it is working wonderful for my usecase (two different monitors (desktop monitor & TV) always connected via HDMI, but the TV should not be configured in a row, but in single mode). This is now doable, because I can distinguish them by their monitor ID. Now I can also add a script to `execute_after` to change the Pulse output to the TV, if my TV is connected.

This is of course not an extensive test and I have not tested the new code with every configuration option, but I extended all existing tests as needed.

Fixes #10

Please let me know what you think, I would like to get this merged, but I don't think that I will come up with a good way to change the configuration language on my own.