### PR TITLE
Add the systemd service to PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexander Neumann <alexander@bumpern.de>
 options=(!strip)
 pkgname=grobi-git
-pkgver=r27.e549af2
+pkgver=r70.4f1d8e5
 pkgrel=1
 pkgdesc="grobi automates applying xrandr profiles when outputs change"
 arch=('i686' 'x86_64')
@@ -28,6 +28,7 @@ package() {
   install -Dm755 "$pkgname/grobi"    "$pkgdir/usr/bin/grobi"
   install -Dm644 "$pkgname/LICENSE"   "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
   install -Dm644 "$pkgname/README.md" "$pkgdir/usr/share/doc/$pkgname/README"
+  install -Dm644 "$pkgname/doc/grobi.service" "$pkgdir/usr/lib/systemd/user/grobi.service"
 }
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
This is just a small update to the PKGBUILD.
I was wondering why grobi was not in the AUR.
Would you mind, if I uploaded this PKGBUILD to the AUR?