### PR TITLE
Add --active-poll option

### DIFF
--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -100,7 +100,7 @@ func (cmd CmdWatch) Execute(args []string) error {
 			var outputs Outputs
 			var err error
 
-			if eventReceived {
+			if eventReceived || globalOpts.ActivePoll {
 				outputs, err = DetectOutputs()
 				eventReceived = false
 			} else {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ type GlobalOptions struct {
 	Config       string `short:"C" long:"config"                      description:"Read config from this file"`
 	DryRun       bool   `short:"n" long:"dry-run"                     description:"Only print what commands would be executed without actually runnig them"`
 	PollInterval uint   `short:"i" long:"interval"    default:"2"     description:"Number of seconds between polls, set to zero to disable polling"`
+	ActivePoll   bool   `short:"a" long:"active-poll"                 description:"Force xrandr to re-detect outputs during polling"`
 	Pause        uint   `short:"p" long:"pause"       default:"0"     description:"Number of seconds to pause after a change was executed"`
 	Logfile      string `short:"l" long:"logfile"                     description:"Write log to file"`
 


### PR DESCRIPTION
My Nvidia/X setup fails to trigger X events on HDMI disconnect.
However, I was able to manually make xrandr notice the change by calling "grobi show" or "xrandr".
So I introduced that switch which makes "grobi watch" call "xrandr" periodically (instead of "xrandr --current"), which, according to the xrandr manual, "Return[s] the current screen configuration, without polling for hardware changes".

I wasn't totally sure what to call the switch, so now it's called "--active-poll/-a", but feel free to find a better name.