### PR TITLE
Support configuration by monitor id only

### DIFF
--- a/randr.go
+++ b/randr.go
@@ -101,6 +101,15 @@ func (os Outputs) Present(name string) bool {
 			return true
 		}
 
+		// Check monitory id only
+		m, err = path.Match(name, o.MonitorId)
+		if err != nil {
+			return false
+		}
+		if m {
+			return true
+		}
+
 		// Check extended name
 		m, err = path.Match(name, o.Name+"-"+o.MonitorId)
 		if err != nil {
@@ -123,6 +132,15 @@ func (os Outputs) Connected(name string) bool {
 
 		// Check legacy name
 		m, err := path.Match(name, o.Name)
+		if err != nil {
+			return false
+		}
+		if m {
+			return true
+		}
+
+		// Check monitory id only
+		m, err = path.Match(name, o.MonitorId)
 		if err != nil {
 			return false
 		}
@@ -515,6 +533,14 @@ func BuildCommandOutputRow(rule Rule, current Outputs) ([]*exec.Cmd, error) {
 		mode := ""
 		if len(data) > 1 {
 			mode = data[1]
+		}
+
+		for _, disp := range current {
+			if disp.MonitorId == name {
+				V("set output %s to %s\n", disp.MonitorId, disp.Name)
+				name = disp.Name
+				break
+			}
 		}
 
 		active[name] = struct{}{}


### PR DESCRIPTION
This allows you to specify a monitor id alone for both output matching and for output configuration. 

I've got a dock that every time I plug into it it show up as a different output (e.g. dp-4 then dp-5). This made it difficult to get hot plugging to work properly. 

The change allows for the output configuration to use the monitor id instead of the output name. 

I also changed randr Present()/Connected() methods to be able to match on just the output name. This isn't strictly necessary since you can use wildcards but it seemed a bit confusing to require a wildcard for the outputs_connected config and then a strict match for the configure_row config.