### PR TITLE
Add ability to have vertical monitors

### DIFF
--- a/doc/grobi.conf
+++ b/doc/grobi.conf
@@ -30,7 +30,7 @@ rules:
         - HDMI2
         - HDMI3
 
-    # vertical_row flips the row vertial, so monitors are on top of eachother.
+    # vertical_row flips the row vertical, so monitors are on top of eachother.
     vertical_row: false
 
     # atomic instructs grobi to only call xrandr once and configure all the

--- a/doc/grobi.conf
+++ b/doc/grobi.conf
@@ -30,6 +30,9 @@ rules:
         - HDMI2
         - HDMI3
 
+    # vertical_row flips the row vertial, so monitors are on top of eachother.
+    vertical_row: false
+
     # atomic instructs grobi to only call xrandr once and configure all the
     # outputs. This does not always work with all graphic cards.
     atomic: true

--- a/randr.go
+++ b/randr.go
@@ -528,7 +528,11 @@ func BuildCommandOutputRow(rule Rule, current Outputs) ([]*exec.Cmd, error) {
 		}
 
 		if i > 0 {
-			args = append(args, "--right-of", lastOutput)
+			if rule.VerticalRow {
+				args = append(args, "--above", lastOutput)
+			} else {
+				args = append(args, "--right-of", lastOutput)
+			}
 		}
 
 		if rule.Primary == name {

--- a/rule.go
+++ b/rule.go
@@ -13,6 +13,8 @@ type Rule struct {
 	ConfigureSingle  string   `yaml:"configure_single"`
 	ConfigureCommand string   `yaml:"configure_command"`
 
+	VerticalRow bool `yaml:"vertical_row"`
+
 	Primary string `yaml:"primary"`
 
 	DisableOrder []string `yaml:"disable_order"`


### PR DESCRIPTION
Very nice program, it just works, which is nice, so thanks for creating grobi.
I often have laptop screen below external screen, so having them --above instead of --right-of would be nice.
So I made this bool config, did not want to try make a fully customizable grid of screens (I dont have that many screens anyways), just a switch, to make the existing config_row vertical.