### PR TITLE
Add support for rate

### DIFF
--- a/cmd_apply.go
+++ b/cmd_apply.go
@@ -26,14 +26,14 @@ func (cmd CmdApply) Usage() string {
 }
 
 func ApplyRule(outputs Outputs, rule Rule) error {
-	var cmds []*exec.Cmd
+	var cmds commands
 	var err error
 
 	switch {
 	case rule.ConfigureSingle != "" || len(rule.ConfigureRow) > 0 || len(rule.ConfigureColumn) > 0:
 		cmds, err = BuildCommandOutputRow(rule, outputs)
 	case rule.ConfigureCommand != "":
-		cmds = []*exec.Cmd{exec.Command("sh", "-c", rule.ConfigureCommand)}
+		cmds = commands{command{"sh", "-c", rule.ConfigureCommand}}
 	default:
 		return fmt.Errorf("no output configuration for rule %v", rule.Name)
 	}
@@ -45,7 +45,7 @@ func ApplyRule(outputs Outputs, rule Rule) error {
 	foundError := false
 	for _, cmd := range cmds {
 		for i := 0; i < 4; i++ {
-			err = RunCommand(cmd)
+			err = RunCommand(cmd.Cmd())
 			if err == nil {
 				break
 			}

--- a/config.go
+++ b/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	OnFailure    []string `yaml:"on_failure"`
 }
 
-// xdgConfigDir returns the config directory according to the xdg standard, see
+// xdgConfigDir returns the config directory according to the xdg standard, see.
 // http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html.
 func xdgConfigDir() string {
 	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
@@ -37,7 +37,8 @@ func openConfigFile(name string) (io.ReadCloser, error) {
 		os.Getenv("GROBI_CONFIG"),
 		filepath.Join(xdgConfigDir(), "grobi.conf"),
 		filepath.Join(os.Getenv("HOME"), ".grobi.conf"),
-		"/etc/xdg/grobi.conf"} {
+		"/etc/xdg/grobi.conf",
+	} {
 		if filename != "" {
 			if f, err := os.Open(filename); err == nil {
 				V("reading config from %v\n", filename)
@@ -81,7 +82,6 @@ func readConfig(name string) (Config, error) {
 
 // Valid returns an error if the config is invalid, ie a pattern is malformed.
 func (cfg Config) Valid() error {
-
 	for _, rule := range cfg.Rules {
 		for _, list := range [][]string{rule.OutputsPresent, rule.OutputsAbsent, rule.OutputsConnected, rule.OutputsDisconnected} {
 			for _, pat := range list {

--- a/main.go
+++ b/main.go
@@ -56,8 +56,10 @@ func RunCommand(cmd *exec.Cmd) error {
 	return cmd.Run()
 }
 
-var globalOpts = GlobalOptions{}
-var parser = flags.NewParser(&globalOpts, flags.Default)
+var (
+	globalOpts = GlobalOptions{}
+	parser     = flags.NewParser(&globalOpts, flags.Default)
+)
 
 func V(s string, data ...interface{}) {
 	if globalOpts.Verbose && globalOpts.log == nil {

--- a/rule.go
+++ b/rule.go
@@ -26,14 +26,20 @@ type Rule struct {
 }
 
 func (r Rule) OutputsDiff(old Rule) Outputs {
-	outputs := []string{r.ConfigureSingle}
+	outputs := []string{}
+	if r.ConfigureSingle != "" {
+		outputs = append(outputs, r.ConfigureSingle)
+	}
 	outputs = append(outputs, r.ConfigureRow...)
 	outputs = append(outputs, r.ConfigureColumn...)
 	for k, v := range outputs {
 		outputs[k] = strings.SplitN(v, "@", 2)[0]
 	}
 
-	outputsOld := []string{old.ConfigureSingle}
+	outputsOld := []string{}
+	if old.ConfigureSingle != "" {
+		outputsOld = append(outputsOld, old.ConfigureSingle)
+	}
 	outputsOld = append(outputsOld, old.ConfigureRow...)
 	outputsOld = append(outputsOld, old.ConfigureColumn...)
 	for k, v := range outputsOld {

--- a/rule.go
+++ b/rule.go
@@ -1,5 +1,7 @@
 package main
 
+import "strings"
+
 // Rule is a rule to configure outputs.
 type Rule struct {
 	Name string
@@ -21,6 +23,38 @@ type Rule struct {
 	Atomic bool `yaml:"atomic"`
 
 	ExecuteAfter []string `yaml:"execute_after"`
+}
+
+func (r Rule) OutputsDiff(old Rule) Outputs {
+	outputs := []string{r.ConfigureSingle}
+	outputs = append(outputs, r.ConfigureRow...)
+	outputs = append(outputs, r.ConfigureColumn...)
+	for k, v := range outputs {
+		outputs[k] = strings.SplitN(v, "@", 2)[0]
+	}
+
+	outputsOld := []string{old.ConfigureSingle}
+	outputsOld = append(outputsOld, old.ConfigureRow...)
+	outputsOld = append(outputsOld, old.ConfigureColumn...)
+	for k, v := range outputsOld {
+		outputsOld[k] = strings.SplitN(v, "@", 2)[0]
+	}
+
+	var diff Outputs
+	for _, old := range outputsOld {
+		foundInOutputs := false
+		for _, v := range outputs {
+			if old == v {
+				foundInOutputs = true
+			}
+		}
+
+		if !foundInOutputs {
+			diff = append(diff, Output{Name: old})
+		}
+	}
+
+	return diff
 }
 
 // Match returns true iff the rule matches for the given list of outputs.

--- a/rule_test.go
+++ b/rule_test.go
@@ -1,6 +1,8 @@
 package main
 
-import "testing"
+import (
+	"testing"
+)
 
 var testRules = []struct {
 	rule  Rule
@@ -112,5 +114,21 @@ func TestRuleMatch(t *testing.T) {
 			t.Errorf("test rule %d wrong match: wanted %v, got %v", i, test.match, m)
 			continue
 		}
+	}
+}
+
+func TestOutputsDiff(t *testing.T) {
+	old := Rule{
+		ConfigureRow:    []string{"one"},
+		ConfigureColumn: []string{"two"},
+	}
+	new := Rule{
+		ConfigureRow:    []string{"one"},
+		ConfigureColumn: []string{"three"},
+	}
+
+	diff := new.OutputsDiff(old)
+	if diff[0].Name != "two" {
+		t.Errorf("expected diff to be two got: %s", diff[0].Name)
 	}
 }


### PR DESCRIPTION
Also fixed a few other things:
- bugs in active mode detection with displays with multiple rates (144hz and 60hz in my case). Updated test cases. 
- Turn off changed displays in a smarter way. Im using usb-c daisychain
and had trouble with the current approach. it disabled my screen as soon
as the screen went into hibernate because xrandr stopped detecting the
display.
- some autoformatting of comments and code according to efficient go
guidelines
- if xrand (ApplyRule) fails, try 3 times with a little more sleep each
time. This also solved issues with my daisychained displays.
- dont execute_after if xrandr fails 3 times. 

Fixes #29