### PR TITLE
randr: removes extra junk from the edid serial number

### DIFF
--- a/randr.go
+++ b/randr.go
@@ -242,6 +242,11 @@ func GenerateMonitorID(s string) (string, error) {
 		}
 	}
 
+	// clean up some junk from the edid serial number
+	for _, old := range []string{"\n", "\xff"} {
+		displaySerialNumber = strings.ReplaceAll(displaySerialNumber, old, "")
+	}
+
 	str := fmt.Sprintf("%s-%d-%d-%v-%v", manufacturer, product, serial, displayName, displaySerialNumber)
 	return str, nil
 }


### PR DESCRIPTION
Some docking pads have extra bytes in edid serial number, this prevented matching in the configuration file.

Before change:
  $ grobi show
  eDP-1      LEN-16570-0--
  DP-2-2-8   LEN-25066-0-P27q-20-V9064YWE
  ����

After change:
  $ grobi show
  eDP-1      LEN-16570-0--
  DP-2-2-8   LEN-25066-0-P27q-20-V9064YWE